### PR TITLE
Enables Octokit pagination for larger datasets

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -15,6 +15,7 @@ stack = Faraday::RackBuilder.new do |builder|
   builder.adapter Faraday.default_adapter
 end
 Octokit.middleware = stack
+Octokit.auto_paginate = true
 
 get '/' do
   if session[:user]


### PR DESCRIPTION
I was having issues with loading some users with a large amount of PRs.

Enabling pagination is an easy win :+1: 
